### PR TITLE
Fixed mismatched naming convention

### DIFF
--- a/src/BBParser.php
+++ b/src/BBParser.php
@@ -142,9 +142,9 @@ class BBParser
      * @param  string  $content
      * @return self
      */
-    public function addTag(string $name, string $search, string $replace, string $content) : self
+    public function addTag(string $name, string $pattern, string $replace, string $content) : self
     {
-        $this->bbcodes[$name] =compact('search', 'replace', 'content');
+        $this->bbcodes[$name] =compact('pattern', 'replace', 'content');
         $this->enabledBBCodes[$name] = $this->bbcodes[$name];
 
         return $this;


### PR DESCRIPTION
Add Tag is currently broken add it adds the pattern using the "search" key resulting in a "Unknown named parameter $pattern" error during iteration of tags.